### PR TITLE
Add example Spark plugin project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# spark-plugins
+# Spark Plugins
+
+This repository contains an example Spark plugin written in Scala and built with sbt.
+
+The plugin implements the `SparkPlugin` interface to demonstrate driver and executor lifecycle hooks.
+
+## Building
+
+Run the following command to build the plugin JAR:
+
+```bash
+sbt package
+```
+
+The resulting artifact will be found under `target/scala-2.12/`.
+
+## Usage
+
+Include the plugin JAR on Spark's classpath and specify the plugin via `spark.plugins`:
+
+```bash
+spark-submit \
+  --conf "spark.plugins=com.example.plugin.ExampleSparkPlugin" \
+  --class your.MainClass your-app.jar
+```
+
+When enabled, the plugin prints simple log messages during initialization and shutdown on both the driver and executors.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This repository contains an example Spark plugin written in Scala and built with
 
 The plugin implements the `SparkPlugin` interface to demonstrate driver and executor lifecycle hooks.
 
+## Testing
+
+Run the unit tests with:
+
+```bash
+sbt test
+```
+
 ## Building
 
 Run the following command to build the plugin JAR:

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,10 @@
+name := "spark-plugins"
+
+version := "0.1.0"
+
+scalaVersion := "2.12.18"
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % "3.5.0" % "provided",
+  "org.apache.spark" %% "spark-sql" % "3.5.0" % "provided"
+)

--- a/build.sbt
+++ b/build.sbt
@@ -6,5 +6,6 @@ scalaVersion := "2.12.18"
 
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "3.5.0" % "provided",
-  "org.apache.spark" %% "spark-sql" % "3.5.0" % "provided"
+  "org.apache.spark" %% "spark-sql" % "3.5.0" % "provided",
+  "org.scalatest" %% "scalatest" % "3.2.18" % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/src/main/resources/META-INF/services/org.apache.spark.api.plugin.SparkPlugin
+++ b/src/main/resources/META-INF/services/org.apache.spark.api.plugin.SparkPlugin
@@ -1,0 +1,1 @@
+com.example.plugin.ExampleSparkPlugin

--- a/src/main/scala/com/example/plugin/ExampleSparkPlugin.scala
+++ b/src/main/scala/com/example/plugin/ExampleSparkPlugin.scala
@@ -1,0 +1,35 @@
+package com.example.plugin
+
+import org.apache.spark.SparkContext
+import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
+
+/** Example Spark plugin demonstrating driver and executor lifecycle hooks. */
+class ExampleSparkPlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new ExampleDriverPlugin
+  override def executorPlugin(): ExecutorPlugin = new ExampleExecutorPlugin
+}
+
+class ExampleDriverPlugin extends DriverPlugin {
+  override def init(sc: SparkContext, ctx: PluginContext): java.util.Map[String, String] = {
+    // initialization logic on the driver
+    println("ExampleDriverPlugin initialized")
+    java.util.Collections.emptyMap[String, String]
+  }
+
+  override def shutdown(): Unit = {
+    // cleanup logic on the driver
+    println("ExampleDriverPlugin shutdown")
+  }
+}
+
+class ExampleExecutorPlugin extends ExecutorPlugin {
+  override def init(ctx: PluginContext, extraConf: java.util.Map[String, String]): Unit = {
+    // initialization logic on executors
+    println("ExampleExecutorPlugin initialized")
+  }
+
+  override def shutdown(): Unit = {
+    // cleanup logic on executors
+    println("ExampleExecutorPlugin shutdown")
+  }
+}

--- a/src/test/scala/com/example/plugin/ExampleSparkPluginSuite.scala
+++ b/src/test/scala/com/example/plugin/ExampleSparkPluginSuite.scala
@@ -1,0 +1,9 @@
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExampleSparkPluginSuite extends AnyFunSuite {
+  test("driverPlugin and executorPlugin return expected instances") {
+    val plugin = new com.example.plugin.ExampleSparkPlugin
+    assert(plugin.driverPlugin().isInstanceOf[com.example.plugin.ExampleDriverPlugin])
+    assert(plugin.executorPlugin().isInstanceOf[com.example.plugin.ExampleExecutorPlugin])
+  }
+}


### PR DESCRIPTION
## Summary
- initialize sbt build files
- implement `ExampleSparkPlugin` with driver and executor hooks
- register the plugin via service definition
- add project README with build and usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68597aef9ca0832d958c1ecbdf6f79c6