### PR TITLE
Add spark-testing-base and refactor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# spark-plugins
+# Spark Plugins
+
+This repository contains an example Spark plugin written in Scala and built with sbt.
+
+The plugin implements the `SparkPlugin` interface to demonstrate driver and executor lifecycle hooks.
+
+## Testing
+
+This project uses the [spark-testing-base](https://github.com/holdenk/spark-testing-base)
+framework for unit tests. Run them with:
+
+```bash
+sbt test
+```
+
+## Building
+
+Run the following command to build the plugin JAR:
+
+```bash
+sbt package
+```
+
+The resulting artifact will be found under `target/scala-2.12/`.
+
+## Usage
+
+Include the plugin JAR on Spark's classpath and specify the plugin via `spark.plugins`:
+
+```bash
+spark-submit \
+  --conf "spark.plugins=com.example.plugin.ExampleSparkPlugin" \
+  --class your.MainClass your-app.jar
+```
+
+When enabled, the plugin prints simple log messages during initialization and shutdown on both the driver and executors.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,12 @@
+name := "spark-plugins"
+
+version := "0.1.0"
+
+scalaVersion := "2.12.18"
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % "3.5.0" % "provided",
+  "org.apache.spark" %% "spark-sql" % "3.5.0" % "provided",
+  "org.scalatest" %% "scalatest" % "3.2.18" % Test,
+  "com.holdenkarau" %% "spark-testing-base" % "3.5.0_1.4.0" % Test
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/src/main/resources/META-INF/services/org.apache.spark.api.plugin.SparkPlugin
+++ b/src/main/resources/META-INF/services/org.apache.spark.api.plugin.SparkPlugin
@@ -1,0 +1,1 @@
+com.example.plugin.ExampleSparkPlugin

--- a/src/main/scala/com/example/plugin/ExampleSparkPlugin.scala
+++ b/src/main/scala/com/example/plugin/ExampleSparkPlugin.scala
@@ -1,0 +1,35 @@
+package com.example.plugin
+
+import org.apache.spark.SparkContext
+import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
+
+/** Example Spark plugin demonstrating driver and executor lifecycle hooks. */
+class ExampleSparkPlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new ExampleDriverPlugin
+  override def executorPlugin(): ExecutorPlugin = new ExampleExecutorPlugin
+}
+
+class ExampleDriverPlugin extends DriverPlugin {
+  override def init(sc: SparkContext, ctx: PluginContext): java.util.Map[String, String] = {
+    // initialization logic on the driver
+    println("ExampleDriverPlugin initialized")
+    java.util.Collections.emptyMap[String, String]
+  }
+
+  override def shutdown(): Unit = {
+    // cleanup logic on the driver
+    println("ExampleDriverPlugin shutdown")
+  }
+}
+
+class ExampleExecutorPlugin extends ExecutorPlugin {
+  override def init(ctx: PluginContext, extraConf: java.util.Map[String, String]): Unit = {
+    // initialization logic on executors
+    println("ExampleExecutorPlugin initialized")
+  }
+
+  override def shutdown(): Unit = {
+    // cleanup logic on executors
+    println("ExampleExecutorPlugin shutdown")
+  }
+}

--- a/src/test/scala/com/example/plugin/ExampleSparkPluginSuite.scala
+++ b/src/test/scala/com/example/plugin/ExampleSparkPluginSuite.scala
@@ -1,0 +1,22 @@
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.apache.spark.SparkConf
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Unit tests for ExampleSparkPlugin using spark-testing-base */
+class ExampleSparkPluginSuite extends AnyFunSuite with SharedSparkContext {
+  override def conf: SparkConf = {
+    super.conf
+      .setAppName("plugin-test")
+      .set("spark.plugins", "com.example.plugin.ExampleSparkPlugin")
+  }
+
+  test("driverPlugin and executorPlugin return expected instances") {
+    val plugin = new ExampleSparkPlugin
+    assert(plugin.driverPlugin().isInstanceOf[ExampleDriverPlugin])
+    assert(plugin.executorPlugin().isInstanceOf[ExampleExecutorPlugin])
+  }
+
+  test("SparkContext starts with ExampleSparkPlugin") {
+    assert(sc.isStopped === false)
+  }
+}


### PR DESCRIPTION
## Summary
- add spark-testing-base dependency in `build.sbt`
- refactor `ExampleSparkPluginSuite` to use `SharedSparkContext`
- mention spark-testing-base in README

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597aef9ca0832d958c1ecbdf6f79c6