### PR TITLE
Fix CI to install sbt

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -27,6 +27,10 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: 'sbt'
+    - name: Install sbt
+      uses: coursier/setup-action@v1
+      with:
+        apps: sbt
     - name: Run tests
       run: sbt test
       # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository


### PR DESCRIPTION
## Summary
- update Scala CI workflow to install sbt

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597e8fdadc832db10e6cc5b55322e0