### PR TITLE
Add RDD recomputation listener

### DIFF
--- a/src/main/scala/com/example/listener/RDDRecomputeListener.scala
+++ b/src/main/scala/com/example/listener/RDDRecomputeListener.scala
@@ -1,0 +1,52 @@
+package com.example.listener
+
+import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted, SparkListenerStageSubmitted, StageInfo}
+import org.apache.spark.storage.StorageLevel
+
+import scala.collection.mutable
+
+/**
+ * Spark listener that tracks RDD usage across stages/jobs and warns when an RDD
+ * is computed multiple times without being persisted.
+ */
+class RDDRecomputeListener extends SparkListener {
+
+  private val rddUsage = mutable.Map[Int, Int]()
+  private val persisted = mutable.Set[Int]()
+
+  override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
+    updateStageRDDs(stageSubmitted.stageInfo)
+  }
+
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
+    updateStageRDDs(stageCompleted.stageInfo)
+  }
+
+  private def updateStageRDDs(stageInfo: StageInfo): Unit = {
+    for (info <- stageInfo.rddInfos) {
+      val id = info.id
+      val count = rddUsage.getOrElse(id, 0) + 1
+      rddUsage.update(id, count)
+      if (info.storageLevel != StorageLevel.NONE) {
+        persisted.add(id)
+      }
+      if (count > 1 && !persisted.contains(id)) {
+        // Emit a warning that this RDD has been recomputed.
+        println(s"Warning: RDD '${info.name}' (ID: $id) has been recomputed $count times without persistence")
+      }
+    }
+  }
+
+  /**
+   * Returns a map of RDD id to the number of times it was used across stages.
+   */
+  def usageMetrics: Map[Int, Int] = rddUsage.toMap
+
+  /**
+   * Returns RDD ids that were recomputed at least twice without persistence and
+   * the number of times they were seen.
+   */
+  def recomputedRDDs: Map[Int, Int] = rddUsage.filter {
+    case (id, count) => count > 1 && !persisted.contains(id)
+  }.toMap
+}

--- a/src/test/scala/com/example/listener/RDDRecomputeListenerSuite.scala
+++ b/src/test/scala/com/example/listener/RDDRecomputeListenerSuite.scala
@@ -1,0 +1,78 @@
+package com.example.listener
+
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.scalatest.funsuite.AnyFunSuite
+
+class RDDRecomputeListenerSuite extends AnyFunSuite with SharedSparkContext {
+
+  test("detect recomputation for non-persisted RDD") {
+    val listener = new RDDRecomputeListener
+    sc.addSparkListener(listener)
+
+    val rdd = sc.parallelize(1 to 10).map(_ + 1)
+    rdd.count()
+    rdd.collect()
+
+    val recomputed = listener.recomputedRDDs
+    assert(recomputed.contains(rdd.id))
+    assert(recomputed(rdd.id) >= 2)
+  }
+
+  test("no recomputation warning for persisted RDD") {
+    val listener = new RDDRecomputeListener
+    sc.addSparkListener(listener)
+
+    val rdd = sc.parallelize(1 to 10).map(_ + 1).persist()
+    rdd.count()
+    rdd.collect()
+
+    assert(!listener.recomputedRDDs.contains(rdd.id))
+  }
+
+  test("usageMetrics counts recomputations") {
+    val listener = new RDDRecomputeListener
+    sc.addSparkListener(listener)
+
+    val rdd = sc.parallelize(1 to 5).map(_ * 2)
+    rdd.count()
+    rdd.collect()
+    rdd.reduce(_ + _)
+
+    val metrics = listener.usageMetrics
+    assert(metrics.contains(rdd.id))
+    assert(metrics(rdd.id) >= 3)
+    assert(listener.recomputedRDDs(rdd.id) >= 3)
+  }
+
+  test("detect recomputation through DataFrame API") {
+    val listener = new RDDRecomputeListener
+    sc.addSparkListener(listener)
+
+    val spark = org.apache.spark.sql.SparkSession.builder()
+      .config(sc.getConf)
+      .getOrCreate()
+    import spark.implicits._
+
+    val baseRdd = sc.parallelize(1 to 4)
+    val df = baseRdd.toDF("value")
+    df.count()
+    df.collect()
+
+    assert(listener.recomputedRDDs.contains(baseRdd.id))
+  }
+
+  test("detect recomputation for range DataFrame without persist") {
+    val listener = new RDDRecomputeListener
+    sc.addSparkListener(listener)
+
+    val spark = org.apache.spark.sql.SparkSession.builder()
+      .config(sc.getConf)
+      .getOrCreate()
+
+    val df = spark.range(0, 5)
+    df.count()
+    df.collect()
+
+    assert(listener.recomputedRDDs.nonEmpty)
+  }
+}


### PR DESCRIPTION
## Summary
- implement `RDDRecomputeListener` to track RDD usage
- flag RDDs recomputed without persistence
- add unit tests for the listener and DataFrame API
- add test for DataFrame from `spark.range`

## Testing
- `sbt -no-colors test`


------
https://chatgpt.com/codex/tasks/task_e_685986f93c90832d8249163bff28d1f6